### PR TITLE
[DOON-25] JwtTokenProvider 추가

### DIFF
--- a/doonut-app-external-api/build.gradle.kts
+++ b/doonut-app-external-api/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    //test
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.6.2")
     testImplementation("io.kotest:kotest-framework-datatest:5.6.2")
     testImplementation("io.mockk:mockk:1.12.4")
@@ -42,6 +44,11 @@ dependencies {
 
     // webflux
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    // jwt
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 tasks {

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/JwtTokenProvider.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/JwtTokenProvider.kt
@@ -1,0 +1,45 @@
+package com.doonutmate.oauth
+
+import com.doonutmate.oauth.exception.InvalidTokenException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.Date
+import javax.crypto.SecretKey
+
+
+@Component
+class JwtTokenProvider(
+    @Value("\${security.jwt.token.secret-key}") secretKey: String,
+    @Value("\${security.jwt.token.expire-length}") private val validityInMilliseconds: Long
+) {
+    private val key: SecretKey = Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
+
+    fun createToken(payload: String?): String {
+        val now = Date()
+        val validity = Date(now.time + validityInMilliseconds)
+        return Jwts.builder()
+            .setSubject(payload)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun getPayload(token: String?): String {
+        return try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
+                .subject
+        } catch (e: JwtException) {
+            throw InvalidTokenException()
+        }
+    }
+}

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/exception/InvalidTokenException.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/exception/InvalidTokenException.kt
@@ -1,0 +1,3 @@
+package com.doonutmate.oauth.exception
+
+class InvalidTokenException : RuntimeException("유효하지 않은 토큰입니다.")

--- a/doonut-app-external-api/src/test/kotlin/com/doonutmate/oauth/JwtTokenProviderTest.kt
+++ b/doonut-app-external-api/src/test/kotlin/com/doonutmate/oauth/JwtTokenProviderTest.kt
@@ -1,0 +1,49 @@
+package com.doonutmate.oauth
+
+import com.doonutmate.oauth.exception.InvalidTokenException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class JwtTokenProviderTest : BehaviorSpec({
+
+    val secretKey = "dasdc338hfhghsn21sdf1jvnu4ascasv21908fyhas2a"
+    val validityInMilliseconds = 3600000L
+
+    Given("payload가 주어지면") {
+        val payload = "dummy_payload"
+        val jwtTokenProvider = JwtTokenProvider(secretKey, validityInMilliseconds)
+        When("JwtTokenProvider는") {
+            val token = jwtTokenProvider.createToken(payload)
+            Then("토큰을 생성한다.") {
+                token shouldNotBe null
+            }
+        }
+    }
+
+    Given("토큰이 주어지면") {
+        val expected = "dummy_payload"
+        val jwtTokenProvider = JwtTokenProvider(secretKey, validityInMilliseconds)
+        val token = jwtTokenProvider.createToken(expected)
+        When("JwtTokenProvider는") {
+            val actual = jwtTokenProvider.getPayload(token)
+            Then("토큰 페이로드를 반환한다.") {
+                actual shouldBe expected
+            }
+        }
+    }
+
+    Given("기간이 만료된 토큰이 주어지면") {
+        val expected = "dummy_payload"
+        val jwtTokenProvider = JwtTokenProvider(secretKey, 0)
+        val token = jwtTokenProvider.createToken(expected)
+        When("JwtTokenProvider는") {
+            Then("에러가 발생한다.") {
+                shouldThrow<InvalidTokenException> {
+                    jwtTokenProvider.getPayload(token)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
userId를 통해 jwt accessToken을 발급할 수 있는 JwtTokenProvider를 추가했습니다.  

서브모듈 내 application.yml에 jwt secret-key, expire-length를 업데이트 했기 때문에 로컬에서 적용하려면 터미널에서 아래 명령어를 입력해야합니다.

```
    git submodule update --remote --merge
```