### PR TITLE
chore: Swagger에서 CORS가 발생하는 에러 수정

### DIFF
--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/DoonutAppExternalApiApplication.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/DoonutAppExternalApiApplication.kt
@@ -1,8 +1,11 @@
 package com.doonutmate
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.servers.Server
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+@OpenAPIDefinition(servers = [Server(url = "/", description = "Default Server URL")])
 @SpringBootApplication
 class DoonutAppExternalApiApplication
 


### PR DESCRIPTION
# 문제 상황  
Swagger 상에서 https로 접속한 뒤 요청을 날리면 CORS가 발생했습니다.  
![스크린샷 2024-03-09 오전 9 34 01](https://github.com/doonutmate/doonut-server/assets/52141636/d2bca328-41c4-4745-9b39-5e008d79d82b)

# 원인
https로 접속했으나 요청은 http로 날라가서 발생한 현상이었습니다.  
<img src="https://github.com/doonutmate/doonut-server/assets/52141636/1e7464e1-55b4-48ce-9224-16ad789dc1be" width="500">

# 해결 방법
[스택오버플로우 참고](https://stackoverflow.com/questions/60625494/wrong-generated-server-url-in-springdoc-openapi-ui-swagger-ui-deployed-behin)

