### PR TITLE
feat: logback 슬랙 알람 설정 추가

### DIFF
--- a/doonut-app-external-api/build.gradle.kts
+++ b/doonut-app-external-api/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     // swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 
+    // slack-log-alarm
+    implementation("com.github.maricn:logback-slack-appender:1.6.1")
+
     // json
     implementation("com.googlecode.json-simple:json-simple:1.1")
 

--- a/doonut-support/src/main/resources/error-file-appender.xml
+++ b/doonut-support/src/main/resources/error-file-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./doonut-support/log/error/error-${BY_DATE}.log</file>
+        <file>./doonut-support/log/error.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>

--- a/doonut-support/src/main/resources/info-file-appender.xml
+++ b/doonut-support/src/main/resources/info-file-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./doonut-support/log/info/info-${BY_DATE}.log</file>
+        <file>./doonut-support/log/info.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>

--- a/doonut-support/src/main/resources/logback-spring.xml
+++ b/doonut-support/src/main/resources/logback-spring.xml
@@ -4,6 +4,8 @@
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+    <property name="SLACK_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{36} - %msg%n"/>
 
     <springProfile name="local,test">
         <include resource="console-appender.xml"/>
@@ -13,15 +15,31 @@
         </root>
     </springProfile>
 
-    <springProfile name="prod,dev">
+    <springProfile name="dev">
         <include resource="error-file-appender.xml"/>
         <include resource="info-file-appender.xml"/>
         <include resource="warn-file-appender.xml"/>
+        <include resource="slack/dev-slack-alarm-appender.xml"/>
 
         <root level="INFO">
             <appender-ref ref="FILE-INFO"/>
             <appender-ref ref="FILE-WARN"/>
             <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="DEV_ASYNC_SLACK"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <include resource="error-file-appender.xml"/>
+        <include resource="info-file-appender.xml"/>
+        <include resource="warn-file-appender.xml"/>
+        <include resource="slack/prod-slack-alarm-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-WARN"/>
+            <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="PROD_ASYNC_SLACK"/>
         </root>
     </springProfile>
 </configuration>

--- a/doonut-support/src/main/resources/slack/dev-slack-alarm-appender.xml
+++ b/doonut-support/src/main/resources/slack/dev-slack-alarm-appender.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-url"/>
+    <appender name="SLACK-DEV-WARN" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <channel>#be-error-alarm-dev</channel>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${SLACK_LOG_PATTERN}</pattern>
+        </layout>
+        <username>알람봇</username>
+        <iconEmoji>:alarmbot:</iconEmoji>
+    </appender>
+
+    <appender name="DEV_ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK-DEV-WARN"/>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>ACCEPT</onMismatch>
+        </filter>
+    </appender>
+</included>

--- a/doonut-support/src/main/resources/slack/prod-slack-alarm-appender.xml
+++ b/doonut-support/src/main/resources/slack/prod-slack-alarm-appender.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-url"/>
+    <appender name="SLACK-PROD-ERROR" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <channel>#be-error-alarm-prod</channel>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${SLACK_LOG_PATTERN}</pattern>
+        </layout>
+        <username>알람봇</username>
+        <iconEmoji>:alarmbot:</iconEmoji>
+    </appender>
+
+    <appender name="PROD_ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK-PROD-ERROR"/>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+</included>

--- a/doonut-support/src/main/resources/warn-file-appender.xml
+++ b/doonut-support/src/main/resources/warn-file-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./doonut-support/log/warn/warn-${BY_DATE}.log</file>
+        <file>./doonut-support/log/warn.log</file>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>
             <onMatch>ACCEPT</onMatch>


### PR DESCRIPTION
# 문제 상황
에러 발생 시 로그를 확인하고 대응하기까지 시간이 많이 걸리는 것 같습니다. 에러 로그가 발생할 때마다 슬랙 채널을 통해 바로 확인할 수 있도록 설정했습니다.

# 해결 방안
슬랙에 2개의 채널을 만들었습니다.
- be-error-alarm-dev
- be-error-alarm-prod

dev 환경에서는 WARN, ERROR 로그를, prod 환경에서는 ERROR 로그를 슬랙 채널로 받도록 설정했습니다.

# 구현 결과
![스크린샷 2024-03-09 오전 11 53 44](https://github.com/doonutmate/doonut-server/assets/52141636/7b6c90fb-5ab5-4f42-a183-50000ee242d7)
