### PR TITLE
fix: 보안파일이 불러와지지 않는 현상 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ out/
 
 ### Log file ###
 *.log
+
+
+### Secret file ###
+*.p8

--- a/doonut-app-external-api/build.gradle.kts
+++ b/doonut-app-external-api/build.gradle.kts
@@ -67,6 +67,7 @@ tasks {
     copy {
         from("../doonut-config")
         include("*.yml")
+        include("*.p8")
         into("src/main/resources")
     }
 


### PR DESCRIPTION
서버환경에서 p8 파일이 불러와지지 않는 현상이 있었는데, 
 -> build gradle task에 복사 스크립트가 빠져 있어서 그랬습니다.