### PR TITLE
feat: 챌린지 이미지 조회 시 타임스탬프 적용

### DIFF
--- a/doonut-core/src/main/java/com/doonutmate/doonut/challenge/model/ChallengeType.java
+++ b/doonut-core/src/main/java/com/doonutmate/doonut/challenge/model/ChallengeType.java
@@ -5,10 +5,17 @@ import lombok.Getter;
 @Getter
 public enum ChallengeType {
     DEFAULT(390, 390),
-    THUMBNAIL(46, 46)
-    ;
+    THUMBNAIL(46, 46);
 
-    public static final String QUERY_STRING_FORMAT = "?w=%s&h=%s";
+    private static final String DEFAULT_URL_QUERY_STRING_FORMAT = "?w=%s&h=%s&swidth=%d&sheight=%d&smargin=%d&sleft=%d&fontSize=%d&stdDeviation=%d&preset=timestamp";
+    private static final String THUMBNAIL_URL_QUERY_STRING_FORMAT = "?w=%s&h=%s";
+    private static final int DEFAULT_SWIDTH = 200;
+    private static final int DEFAULT_SHEIGHT = 50;
+    private static final int DEFAULT_SMARGIN = 20;
+    private static final int DEFAULT_SLEFT = 25;
+    private static final int DEFAULT_FONT_SIZE = 20;
+    private static final int DEFAULT_STD_DEVIATION = 3;
+
     private final int width;
     private final int height;
 
@@ -18,12 +25,13 @@ public enum ChallengeType {
     }
 
     public static String getDefaultUrl(String url) {
-        var queryString = String.format(QUERY_STRING_FORMAT, ChallengeType.DEFAULT.getWidth(), ChallengeType.DEFAULT.getHeight());
+        var queryString = String.format(DEFAULT_URL_QUERY_STRING_FORMAT, ChallengeType.DEFAULT.getWidth(), ChallengeType.DEFAULT.getHeight(),
+                DEFAULT_SWIDTH, DEFAULT_SHEIGHT, DEFAULT_SMARGIN, DEFAULT_SLEFT, DEFAULT_FONT_SIZE, DEFAULT_STD_DEVIATION);
         return url + queryString;
     }
 
     public static String getThumbNailUrl(String url) {
-        var queryString = String.format(QUERY_STRING_FORMAT, ChallengeType.THUMBNAIL.getWidth(), ChallengeType.THUMBNAIL.getHeight());
+        var queryString = String.format(THUMBNAIL_URL_QUERY_STRING_FORMAT, ChallengeType.THUMBNAIL.getWidth(), ChallengeType.THUMBNAIL.getHeight());
         return url + queryString;
     }
 }

--- a/doonut-core/src/test/java/com/doonutmate/doonut/challenge/model/ChallengeTypeTest.java
+++ b/doonut-core/src/test/java/com/doonutmate/doonut/challenge/model/ChallengeTypeTest.java
@@ -10,7 +10,7 @@ class ChallengeTypeTest {
     void getDefaultUrl() {
         // given
         var imageUrl = "https://test.url";
-        var expected = String.format("https://test.url?w=%s&h=%s", ChallengeType.DEFAULT.getWidth(), ChallengeType.DEFAULT.getHeight());
+        var expected = "https://test.url?w=390&h=390&swidth=200&sheight=50&smargin=20&sleft=25&fontSize=20&stdDeviation=3&preset=timestamp";
 
         // when
         var actual = ChallengeType.getDefaultUrl(imageUrl);


### PR DESCRIPTION
## 작업 내용
캘린더 내에서 이미지 클릭 시 타임스탬프가 적용된 이미지가 내려가도록 queryString을 수정했습니다.  

**예시 url** : https://d18xewp1i0fakf.cloudfront.net/dev/20240323/8e0edeab-9f3f-4200-b95c-616b5ba4be88.jpeg?w=390&h=390&swidth=200&sheight=50&smargin=20&sleft=25&fontSize=20&stdDeviation=3&preset=timestamp

**예시 결과** :    
![8e0edeab-9f3f-4200-b95c-616b5ba4be88 (1)](https://github.com/doonutmate/doonut-server/assets/52141636/19ba9b91-8aa6-4904-a624-b299f2d82c2a)

## 성능 측정

AWS lambda 메모리 1024mb 기준 0.2초 정도 걸렸습니다.  

![스크린샷 2024-05-12 오후 10 47 17](https://github.com/doonutmate/doonut-server/assets/52141636/7682723b-82b6-4e76-ab55-a03ef73a1156)

![스크린샷 2024-05-12 오후 10 47 29](https://github.com/doonutmate/doonut-server/assets/52141636/aeac9a2b-2092-48b9-9ec5-78a8d724219c)

