### PR TITLE
feat: 커뮤니티 제한 기능 추가

### DIFF
--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/calendar/controller/CalendarController.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/calendar/controller/CalendarController.kt
@@ -31,11 +31,11 @@ class CalendarController(
     @GetMapping("")
     fun get(
         @RequestParam(required = false) time: Instant?,
-        @RequestParam size: Int?,
+        @RequestParam(required = false, defaultValue = "10") size: Int?,
         @Authorization
         @Parameter(hidden = true)
         memberId: Long,
     ): CalendarResult<CalendarResponse> {
-        return calendarAppService.get(time, size)
+        return calendarAppService.get(time, size, memberId)
     }
 }

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/calendar/exception/CalendarException.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/calendar/exception/CalendarException.kt
@@ -1,0 +1,9 @@
+package com.doonutmate.calendar.exception
+
+import com.doonutmate.exception.BaseException
+import com.doonutmate.exception.ErrorCode
+import org.springframework.http.HttpStatus
+
+class CalendarException(errorCode: ErrorCode?, errorMessage: String) : BaseException(HttpStatus.BAD_REQUEST, errorCode, errorMessage) {
+    constructor(errorMessage: String) : this(null, errorMessage)
+}

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/calendar/service/CalendarAppService.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/calendar/service/CalendarAppService.kt
@@ -2,7 +2,9 @@ package com.doonutmate.calendar.service
 
 import com.doonutmate.calendar.controller.dto.CalendarResponse
 import com.doonutmate.calendar.controller.dto.CalendarResult
+import com.doonutmate.calendar.exception.CalendarException
 import com.doonutmate.doonut.calendar.service.CalendarBusinessService
+import com.doonutmate.exception.ErrorCode
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -14,11 +16,21 @@ class CalendarAppService(
     private val calendarBusinessService: CalendarBusinessService,
     private val calendarFacadeService: CalendarFacadeService,
 ) {
-    fun get(time: Instant?, size: Int?): CalendarResult<CalendarResponse> {
+    fun get(time: Instant?, size: Int?, memberId: Long): CalendarResult<CalendarResponse> {
+        validate(memberId)
         val pageable: Pageable = getBranchPageSize(size)
 
         val calendars: Slice<CalendarResponse> = getBoards(time, pageable)
         return CalendarResult(calendars.toList(), calendars.hasNext())
+    }
+
+    private fun validate(memberId: Long) {
+        val calendar = calendarBusinessService.getByMemberId(memberId)
+            ?: throw CalendarException("캘린더를 찾을 수 없습니다. memberId: $memberId")
+
+        if (calendar.calendarName.isNullOrBlank() || calendar.totalCount < COMMUNITY_ACCESS_MINIMUM_COUNT) {
+            throw CalendarException(ErrorCode.COMMUNITY_NOT_ACCESSIBLE, "커뮤니티는 캘린더명을 설정하고, 3개 이상의 기록이 있어야 확인할 수 있습니다.")
+        }
     }
 
     private fun getBoards(time: Instant?, page: Pageable): Slice<CalendarResponse> {
@@ -31,6 +43,7 @@ class CalendarAppService(
     }
 
     companion object {
-        const val DEFAULT_PAGE_SIZE = 10
+        private const val DEFAULT_PAGE_SIZE = 10
+        private const val COMMUNITY_ACCESS_MINIMUM_COUNT = 3
     }
 }

--- a/doonut-core/src/main/java/com/doonutmate/doonut/calendar/repository/CalendarRepository.java
+++ b/doonut-core/src/main/java/com/doonutmate/doonut/calendar/repository/CalendarRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.Instant;
+import java.util.Optional;
 
 public interface CalendarRepository extends JpaRepository<CalendarEntity, Long> {
     @Query("SELECT c FROM CalendarEntity c ORDER BY c.updatedAt DESC")
@@ -15,4 +16,5 @@ public interface CalendarRepository extends JpaRepository<CalendarEntity, Long> 
     @Query("SELECT c FROM CalendarEntity c WHERE c.updatedAt < :cursor ORDER BY c.updatedAt DESC")
     Slice<CalendarEntity> findLatestCalendar(Instant cursor, Pageable page);
 
+    Optional<CalendarEntity> findByMemberId(Long memberId);
 }

--- a/doonut-core/src/main/java/com/doonutmate/doonut/calendar/service/CalendarBusinessService.java
+++ b/doonut-core/src/main/java/com/doonutmate/doonut/calendar/service/CalendarBusinessService.java
@@ -55,6 +55,12 @@ public class CalendarBusinessService {
                 .orElse(null);
     }
 
+    public Calendar getByMemberId(Long memberId) {
+        return repository.findByMemberId(memberId)
+                .map(mapper::toModel)
+                .orElse(null);
+    }
+
     @Transactional
     public void delete(Long id) {
         var entity = repository.findById(id)

--- a/doonut-core/src/test/java/com/doonutmate/doonut/calendar/service/CalendarBusinessServiceTest.java
+++ b/doonut-core/src/test/java/com/doonutmate/doonut/calendar/service/CalendarBusinessServiceTest.java
@@ -1,0 +1,48 @@
+package com.doonutmate.doonut.calendar.service;
+
+import com.doonutmate.doonut.calendar.model.Calendar;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class CalendarBusinessServiceTest {
+
+    @Autowired
+    private CalendarBusinessService service;
+
+    @Test
+    void getByMemberId() {
+
+        // given
+        var memberId = 1L;
+        var expected = generateCalendar(memberId);
+        var calendarId = service.create(expected);
+
+        // when
+        var actual = service.getByMemberId(memberId);
+
+        // then
+        assertThat(actual)
+                .extracting("id", "memberId", "calendarName", "totalCount")
+                .containsExactly(calendarId, memberId, expected.calendarName(), expected.totalCount());
+    }
+
+    private Calendar generateCalendar(long memberId) {
+        return Calendar.builder()
+                .memberId(memberId)
+                .calendarName("캘린더명")
+                .totalCount(10)
+                .updatedAt(Instant.now())
+                .firstUploadedAt(Instant.now())
+                .lastUploadedAt(Instant.now())
+                .deleted(false)
+                .build();
+    }
+}

--- a/doonut-support/src/main/java/com/doonutmate/exception/ApiErrorHandler.java
+++ b/doonut-support/src/main/java/com/doonutmate/exception/ApiErrorHandler.java
@@ -19,8 +19,8 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
         var errorMessage = getErrorMessage(exception);
         var errorLocation = getErrorLocation(exception);
 
-        log.error("BaseException occurred: {} , Location: {}", errorMessage, errorLocation);
-        return create4xxErrorResponse(exception.getHttpStatus(), errorMessage, request);
+        log.warn("BaseException occurred: {} , Location: {}", errorMessage, errorLocation);
+        return create4xxErrorResponse(exception.getHttpStatus(), exception.getErrorCode(), errorMessage, request);
     }
 
     @ExceptionHandler({RuntimeException.class})
@@ -52,8 +52,8 @@ public class ApiErrorHandler extends ResponseEntityExceptionHandler {
         return exception.getStackTrace()[0];
     }
 
-    private ResponseEntity<ErrorResponse> create4xxErrorResponse(HttpStatus httpStatus, String errorMessage, HttpServletRequest request) {
-        var errorResponse = ErrorResponse.of(httpStatus, errorMessage, request.getRequestURI());
+    private ResponseEntity<ErrorResponse> create4xxErrorResponse(HttpStatus httpStatus, ErrorCode errorCode, String errorMessage, HttpServletRequest request) {
+        var errorResponse = ErrorResponse.of(httpStatus, errorCode, errorMessage, request.getRequestURI());
         return ResponseEntity.badRequest().body(errorResponse);
     }
 

--- a/doonut-support/src/main/java/com/doonutmate/exception/BaseException.java
+++ b/doonut-support/src/main/java/com/doonutmate/exception/BaseException.java
@@ -7,10 +7,18 @@ import org.springframework.http.HttpStatus;
 public class BaseException extends RuntimeException {
 
     private final HttpStatus httpStatus;
+    private final ErrorCode errorCode;
     private final String message;
 
     public BaseException(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
+        this.errorCode = null;
+        this.message = message;
+    }
+
+    public BaseException(HttpStatus httpStatus, ErrorCode errorCode, String message) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
         this.message = message;
     }
 }

--- a/doonut-support/src/main/java/com/doonutmate/exception/ErrorCode.java
+++ b/doonut-support/src/main/java/com/doonutmate/exception/ErrorCode.java
@@ -1,0 +1,5 @@
+package com.doonutmate.exception;
+
+public enum ErrorCode {
+    COMMUNITY_NOT_ACCESSIBLE
+}

--- a/doonut-support/src/main/java/com/doonutmate/exception/ErrorResponse.java
+++ b/doonut-support/src/main/java/com/doonutmate/exception/ErrorResponse.java
@@ -4,11 +4,16 @@ import org.springframework.http.HttpStatus;
 
 public record ErrorResponse(
         int httpStatus,
+        ErrorCode errorCode,
         String message,
         String path
 ) {
 
     public static ErrorResponse of(HttpStatus httpStatus, String message, String path) {
-        return new ErrorResponse(httpStatus.value(), message, path);
+        return new ErrorResponse(httpStatus.value(), null, message, path);
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, ErrorCode errorCode, String message, String path) {
+        return new ErrorResponse(httpStatus.value(), errorCode, message, path);
     }
 }


### PR DESCRIPTION
## 작업 내용
캘린더 제목을 설정하지 않거나 3개 미만의 기록을 갖고 있는 사용자는 커뮤니티를 확인할 수 없도록 유효성 검증을 추가했습니다.

### 유효성 검증 통과 못할 시 응답 결과
```json
{
    "httpStatus": 400,
    "errorCode": "COMMUNITY_NOT_ACCESSIBLE",
    "message": "커뮤니티는 캘린더명을 설정하고, 3개 이상의 기록이 있어야 확인할 수 있습니다."
    "path": "/calendars"
}
```

![스크린샷 2024-05-20 오전 11 10 03](https://github.com/doonutmate/doonut-server/assets/52141636/0ab4eb9b-dea5-4cba-bf9f-c37161100614)

