### PR TITLE
chore: Upgrade Springboot version to 3.2.6 & Flyway 플러그인 추가

### DIFF
--- a/doonut-app-external-api/build.gradle.kts
+++ b/doonut-app-external-api/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "3.1.5"
-    id("io.spring.dependency-management") version "1.1.3"
-    kotlin("jvm") version "1.8.22"
-    kotlin("plugin.spring") version "1.8.22"
+    id("org.springframework.boot") version "3.2.6"
+    id("io.spring.dependency-management") version "1.1.5"
+    kotlin("jvm") version "1.9.24"
+    kotlin("plugin.spring") version "1.9.24"
 }
 
 group = "com.doonutmate"

--- a/doonut-core/build.gradle.kts
+++ b/doonut-core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "3.3.0"
     id("io.spring.dependency-management") version "1.1.3"
+    id("org.flywaydb.flyway") version "10.13.0"
 }
 
 group = "com.doonutmate"

--- a/doonut-core/build.gradle.kts
+++ b/doonut-core/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.1.5"
+    id("org.springframework.boot") version "3.3.0"
     id("io.spring.dependency-management") version "1.1.3"
 }
 

--- a/doonut-core/build.gradle.kts
+++ b/doonut-core/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.3.0"
-    id("io.spring.dependency-management") version "1.1.3"
+    id("org.springframework.boot") version "3.2.6"
+    id("io.spring.dependency-management") version "1.1.5"
     id("org.flywaydb.flyway") version "10.13.0"
 }
 

--- a/doonut-core/build.gradle.kts
+++ b/doonut-core/build.gradle.kts
@@ -5,6 +5,16 @@ plugins {
     id("org.flywaydb.flyway") version "10.13.0"
 }
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.flywaydb:flyway-core:10.13.0")
+        classpath("org.flywaydb:flyway-mysql:10.13.0")
+    }
+}
+
 group = "com.doonutmate"
 version = "0.0.1-SNAPSHOT"
 
@@ -37,8 +47,8 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
 
     // flyway
-    implementation("org.flywaydb:flyway-core")
-    implementation("org.flywaydb:flyway-mysql")
+    implementation("org.flywaydb:flyway-core:10.13.0")
+    implementation("org.flywaydb:flyway-mysql:10.13.0")
 
     implementation("org.mapstruct:mapstruct:1.5.5.Final")
     annotationProcessor("org.mapstruct:mapstruct-processor:1.5.5.Final")

--- a/doonut-support/build.gradle.kts
+++ b/doonut-support/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.1.5"
-    id("io.spring.dependency-management") version "1.1.3"
+    id("org.springframework.boot") version "3.2.6"
+    id("io.spring.dependency-management") version "1.1.5"
 }
 
 group = "com.doonutmate"

--- a/flyway.conf
+++ b/flyway.conf
@@ -1,0 +1,5 @@
+flyway.url=jdbc:mysql://localhost:13306/doonut
+flyway.user=root
+flyway.password=root
+flyway.defaultSchema=doonut
+flyway.schemas=doonut


### PR DESCRIPTION
## 변경 사항
- 스프링부트 버전 업그레이드 3.1.5 -> 3.2.6
- 인텔리제이 내 gradle 탭에 flyway가 표시되도록 설정 추가

### flyway
doonut-core/src/main/resources/db/migration 패키지 내 ddl 문 추가할 때마다 수동으로 터미널에서 flyway migrate 치는게 번거로웠는데, gradle 탭에서 이제 클릭으로 해결할 수 있을 것 같습니다.

<img src="https://github.com/doonutmate/doonut-server/assets/52141636/bca7fdef-41ce-4532-b80d-3b31368f4346"  height="400" />
