### PR TITLE
feat: 다른 사용자의 챌린지 목록 조회 API 추가

### DIFF
--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/configuration/ChallengeConfig.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/configuration/ChallengeConfig.kt
@@ -10,7 +10,10 @@ class ChallengeConfig {
     fun getChallengeApi(): GroupedOpenApi {
         return GroupedOpenApi.builder()
             .group("챌린지")
-            .pathsToMatch("/challenge/**")
+            .pathsToMatch(
+                "/challenge/**",
+                "/members/**/challenges",
+            )
             .pathsToExclude("")
             .packagesToScan("com.doonutmate.challenge.controller")
             .build()

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/controller/ChallengeController.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/controller/ChallengeController.kt
@@ -10,18 +10,19 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @Tag(name = "Challenge", description = "챌린지 API")
-@RequestMapping("/challenge")
+@RequestMapping
 class ChallengeController(
     private val service: ChallengeService,
 ) {
 
     @Operation(summary = "특정 년도 달에 해당하는 챌린지 목록 조회", description = "특정 연월을 입력으로 받으면 챌린지 목록을 반환한다.")
-    @GetMapping
+    @GetMapping("/challenge")
     fun getList(
         @Authorization
         @Parameter(hidden = true)
@@ -31,5 +32,19 @@ class ChallengeController(
         req: ChallengeListRequest,
     ): List<ChallengeListResponse> {
         return service.getChallengeList(memberId, req)
+    }
+
+    @Operation(summary = "다른 사용자의 챌린지 목록 조회")
+    @GetMapping("/members/{otherMemberId}/challenges")
+    fun getOtherMemberChallenges(
+        @Authorization
+        @Parameter(hidden = true)
+        memberId: Long,
+        @PathVariable otherMemberId: Long,
+
+        @Valid @ModelAttribute
+        req: ChallengeListRequest,
+    ): List<ChallengeListResponse> {
+        return service.getChallengeList(otherMemberId, req)
     }
 }


### PR DESCRIPTION
## 작업 내용
다른 사용자의 챌린지 목록을 조회하는 API를 추가했습니다.

### 작업 화면

![스크린샷 2024-06-02 오전 10 52 04](https://github.com/doonutmate/doonut-server/assets/52141636/6891f142-0541-4bac-a1d8-017bd1c0c293)
