### PR TITLE
fix: 회원가입 시 마케팅 수신 동의 해제 날짜가 자동으로 설정되도록 수정

### DIFF
--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/apple/service/AppleOauthProvider.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/apple/service/AppleOauthProvider.kt
@@ -18,6 +18,7 @@ import io.jsonwebtoken.Claims
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.security.PublicKey
+import java.time.Instant
 
 @Service
 class AppleOauthProvider(
@@ -61,7 +62,7 @@ class AppleOauthProvider(
             .serviceAlarm(false)
             .lateNightAlarm(false)
             .marketingReceiveConsent(false)
-            .marketingReceiveConsentUpdatedAt(null)
+            .marketingReceiveConsentUpdatedAt(Instant.now())
             .deleted(false)
             .build()
 

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/kakao/service/KakaoOauthProvider.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/oauth/kakao/service/KakaoOauthProvider.kt
@@ -9,6 +9,7 @@ import com.doonutmate.oauth.kakao.dto.KakaoIdResponse
 import com.doonutmate.oauth.kakao.dto.KakaoInfoResponse
 import com.doonutmate.oauth.service.OauthProvider
 import org.springframework.stereotype.Service
+import java.time.Instant
 
 @Service
 class KakaoOauthProvider(
@@ -34,7 +35,7 @@ class KakaoOauthProvider(
             .serviceAlarm(false)
             .lateNightAlarm(false)
             .marketingReceiveConsent(false)
-            .marketingReceiveConsentUpdatedAt(null)
+            .marketingReceiveConsentUpdatedAt(Instant.now())
             .deleted(false)
             .build()
 


### PR DESCRIPTION
## 변경 사항
회원가입 시 마케팅 수신 동의 해제 날짜가 자동으로 Instant.now()로 설정되도록 수정했습니다.

![스크린샷 2024-08-16 오후 8 29 11](https://github.com/user-attachments/assets/3705117c-8448-49bd-b98a-44362afb8a8e)
