### PR TITLE
feat: 캘린더 조회 응답값에 timestamp 추가

### DIFF
--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/controller/dto/ChallengeListResponse.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/controller/dto/ChallengeListResponse.kt
@@ -1,6 +1,7 @@
 package com.doonutmate.challenge.controller.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 
 @Schema(title = "Challenge 목록 조회 응답")
 data class ChallengeListResponse(
@@ -12,4 +13,7 @@ data class ChallengeListResponse(
 
     @Schema(title = "썸네일 이미지 url")
     val thumbNailUrl: String,
+
+    @Schema(title = "업로드 시간", example = "2024-06-16T21:19:41")
+    var timestamp: LocalDateTime,
 )

--- a/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/service/ChallengeService.kt
+++ b/doonut-app-external-api/src/main/kotlin/com/doonutmate/challenge/service/ChallengeService.kt
@@ -18,6 +18,7 @@ class ChallengeService(
             ChallengeListResponse(
                 defaultUrl = ChallengeType.getDefaultUrl(challenge.imageUrl),
                 thumbNailUrl = ChallengeType.getThumbNailUrl(challenge.imageUrl),
+                timestamp = CommonDateUtils.convertInstantToLocalDateTime(challenge.createdAt),
                 day = CommonDateUtils.getDay(challenge.createdAt),
             )
         }


### PR DESCRIPTION
## 변경사항
캘린더 조회 응답값에 timestamp 값을 추가했습니다.

### 요청
```
curl -X 'GET' \
  'http://localhost:8081/challenge?memberId=5&year=2024&month=6' \
  -H 'accept: */*'
```

### 응답
```
[
  {
    "day": 16,
    "defaultUrl": "https://d18x2ewp1i0fakf.cloudfront.net/dev/20240616/75b8d581-e616-47d4-acdd-1694f1c16c97.jpg?w=1000&h=1000",
    "thumbNailUrl": "https://d182xewp1i0fakf.cloudfront.net/dev/20240616/75b8d581-e616-47d4-acdd-1694f1c16c97.jpg?w=46&h=46",
    "timestamp": "2024-06-16T21:19:41"
  }
]
```